### PR TITLE
[fix] weak global reference table overflow

### DIFF
--- a/library/src/main/cpp/epic.cpp
+++ b/library/src/main/cpp/epic.cpp
@@ -252,7 +252,11 @@ jobject epic_getobject(JNIEnv *env, jclass clazz, jlong self, jlong address) {
     LOGV("java vm: %p, self: %p, address: %p", vm, (void*) self, (void*) address);
     jobject object = addWeakGloablReference(vm, (void *) self, (void *) address);
 
-    return object;
+    jobject result = env->NewLocalRef(object);
+
+    env->DeleteWeakGlobalRef(object);
+
+    return result;
 }
 
 jlong epic_getMethodAddress(JNIEnv *env, jclass clazz, jobject method) {


### PR DESCRIPTION
[https://github.com/tiann/epic/blob/657c1851f32793f440f8f71ad38d57a53acc82a5/library/src/main/cpp/epic.cpp#L253](https://github.com/tiann/epic/blob/657c1851f32793f440f8f71ad38d57a53acc82a5/library/src/main/cpp/epic.cpp#L253)

native方法中返回了WeakGloablReference引用的对象但未释放，导致多次（上万次）拦截被hook的方法后全局弱引用表溢出

解决：
将WeakGloablReference生成LocalReference，然后删除WeakGloablReference，返回LocalReference引用的对象，而LocalReference在离开native层以后将解除引用，故解决了内存泄漏问题

```07-26 23:41:53.219 11409-11409/top.imlk.dynamicmodifyviewtree A/art: art/runtime/indirect_reference_table.cc:116] JNI ERROR (app bug): weak global reference table overflow (max=51200)
    art/runtime/indirect_reference_table.cc:116] weak global reference table dump:
    art/runtime/indirect_reference_table.cc:116]   Last 10 entries (of 51200):
    art/runtime/indirect_reference_table.cc:116]     51199: 0x12dab3c0 top.imlk.dynamicmodifyviewtree.tree.NodeRangeView
    art/runtime/indirect_reference_table.cc:116]     51198: 0x12dab200 top.imlk.dynamicmodifyviewtree.tree.NodeRangeView
    art/runtime/indirect_reference_table.cc:116]     51197: 0x12da5e40 top.imlk.dynamicmodifyviewtree.tree.NodeRangeView
    art/runtime/indirect_reference_table.cc:116]     51196: 0x12da5c80 top.imlk.dynamicmodifyviewtree.tree.NodeRangeView
    art/runtime/indirect_reference_table.cc:116]     51195: 0x12da5ac0 top.imlk.dynamicmodifyviewtree.tree.NodeRangeView
    art/runtime/indirect_reference_table.cc:116]     51194: 0x12da5900 top.imlk.dynamicmodifyviewtree.tree.NodeRangeView
    art/runtime/indirect_reference_table.cc:116]     51193: 0x12da5740 top.imlk.dynamicmodifyviewtree.tree.NodeRangeView
    art/runtime/indirect_reference_table.cc:116]     51192: 0x12da5580 top.imlk.dynamicmodifyviewtree.tree.NodeRangeView
    art/runtime/indirect_reference_table.cc:116]     51191: 0x12da53c0 top.imlk.dynamicmodifyviewtree.tree.NodeRangeView
    art/runtime/indirect_reference_table.cc:116]     51190: 0x12da5200 top.imlk.dynamicmodifyviewtree.tree.NodeRangeView
    art/runtime/indirect_reference_table.cc:116]   Summary:
    art/runtime/indirect_reference_table.cc:116]       432 of top.imlk.dynamicmodifyviewtree.MoveableTextView (27 unique instances)
    art/runtime/indirect_reference_table.cc:116]        28 of android.support.v7.widget.ActionBarOverlayLayout (1 unique instances)
    art/runtime/indirect_reference_table.cc:116]        28 of android.support.v7.widget.ContentFrameLayout (1 unique instances)
    art/runtime/indirect_reference_table.cc:116]        28 of android.support.v7.widget.ActionBarContainer (1 unique instances)
    art/runtime/indirect_reference_table.cc:116]        29 of android.support.v7.widget.AppCompatTextView (1 unique instances)
    art/runtime/indirect_reference_table.cc:116]        28 of android.support.constraint.ConstraintLayout (1 unique instances)
    art/runtime/indirect_reference_table.cc:116]        84 of android.support.v7.widget.AppCompatButton (3 unique instances)
    art/runtime/indirect_reference_table.cc:116]        28 of android.support.constraint.Guideline (1 unique instances)
    art/runtime/indirect_reference_table.cc:116]      1245 of top.imlk.dynamicmodifyviewtree.tree.OverFloatFrame (1 unique instances)
    art/runtime/indirect_reference_table.cc:116]     44014 of top.imlk.dynamicmodifyviewtree.tree.NodeRangeView (49 unique instances)
    art/runtime/indirect_reference_table.cc:116]         1 of java.lang.Thread
    art/runtime/indirect_reference_table.cc:116]         3 of byte[] (1440 elements) (3 unique instances)
    art/runtime/indirect_reference_table.cc:116]         3 of byte[] (5016 elements) (3 unique instances)
    art/runtime/indirect_reference_table.cc:116]         1 of byte[] (6912 elements)
    art/runtime/indirect_reference_table.cc:116]         5 of byte[] (9216 elements) (5 unique instances)
    art/runtime/indirect_reference_table.cc:116]         4 of byte[] (10080 elements) (4 unique instances)
    art/runtime/indirect_reference_table.cc:116]         1 of byte[] (14880 elements)
    art/runtime/indirect_reference_table.cc:116]         1 of byte[] (17280 elements)
    art/runtime/indirect_reference_table.cc:116]         9 of byte[] (20736 elements) (9 unique instances)
    art/runtime/indirect_reference_table.cc:116]        27 of byte[] (26244 elements) (27 unique instances)
    art/runtime/indirect_reference_table.cc:116]         2 of byte[] (27328 elements) (2 unique instances)
    art/runtime/indirect_reference_table.cc:116]         1 of byte[] (32256 elements)
    art/runtime/indirect_reference_table.cc:116]         1 of byte[] (32448 elements)
    art/runtime/indirect_reference_table.cc:116]         2 of byte[] (34848 elements) (2 unique instances)
    art/runtime/indirect_reference_table.cc:116]         2 of byte[] (35344 elements) (2 unique instances)
    art/runtime/indirect_reference_table.cc:116]        16 of byte[] (36864 elements) (16 unique instances)
    art/runtime/indirect_reference_table.cc:116]         5 of byte[] (46656 elements) (5 unique instances)
    art/runtime/indirect_reference_table.cc:116]         3 of byte[] (79488 elements) (3 unique instances)
    art/runtime/indirect_reference_table.cc:116]         1 of byte[] (82368 elements)
    art/runtime/indirect_reference_table.cc:116]         3 of byte[] (82944 elements) (3 unique instances)
    art/runtime/indirect_reference_table.cc:116]         4 of byte[] (108000 elements) (4 unique instances)
    art/runtime/indirect_reference_table.cc:116]         5 of byte[] (270400 elements) (5 unique instances)
    art/runtime/indirect_reference_table.cc:116]        21 of java.lang.DexCache (21 unique instances)
    art/runtime/indirect_reference_table.cc:116]         7 of dalvik.system.PathClassLoader (3 unique instances)
    art/runtime/indirect_reference_table.cc:116]      2388 of android.view.View (2 unique instances)
    art/runtime/indirect_reference_table.cc:116]        28 of android.widget.FrameLayout (1 unique instances)
    art/runtime/indirect_reference_table.cc:116]      1195 of com.android.internal.policy.DecorView (1 unique instances)
    art/runtime/indirect_reference_table.cc:116]        50 of android.widget.FrameLayout$LayoutParams (50 unique instances)
    art/runtime/indirect_reference_table.cc:116]        27 of android.widget.LinearLayout$LayoutParams (27 unique instances)
    art/runtime/indirect_reference_table.cc:116]      1276 of android.widget.LinearLayout (2 unique instances)
    art/runtime/indirect_reference_table.cc:116]       108 of android.view.RenderNode (108 unique instances)
    art/runtime/indirect_reference_table.cc:116]        56 of android.widget.ScrollView (2 unique instances)
    art/runtime/indirect_reference_table.cc:116]
```