### PR TITLE
Support to decode jni id to corresponding ArtMethod address

### DIFF
--- a/library/src/main/cpp/art.cpp
+++ b/library/src/main/cpp/art.cpp
@@ -13,29 +13,73 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-#include <android/log.h>
 #include "art.h"
+#include <android/log.h>
+#include <cstddef>
 
-#define LOGV(...)  ((void)__android_log_print(ANDROID_LOG_INFO, "epic.Native", __VA_ARGS__))
+#define LOGV(...) ((void)__android_log_print(ANDROID_LOG_INFO, "epic.Native", __VA_ARGS__))
 
-void* getHeap(JNIEnv* env, int api) {
-    JavaVM* javaVM;
-    env->GetJavaVM(&javaVM);
-    JavaVMExt *javaVMExt = (JavaVMExt *) javaVM;
+#define ANDROID_R_API 30
+#define MAX_SEARCH_LEN 2000
 
-    void *runtime = javaVMExt->runtime;
-    if (runtime == nullptr) {
-        return nullptr;
+void* ArtHelper::runtime_instance_ = nullptr;
+int ArtHelper::api = 0;
+
+template <typename T>
+inline int find_offset(void* hay, int size, T needle)
+{
+  for (int i = 0; i < size; i += sizeof(T)) {
+    auto current = reinterpret_cast<T*>(reinterpret_cast<char*>(hay) + i);
+    if (*current == needle) {
+      return i;
     }
-
-    if (api < 26) {
-        Runtime_7X *runtime7X = (Runtime_7X *) runtime;
-        return runtime7X->heap_;
-    } else {
-        Runtime_8X *runtime8X = (Runtime_8X *) runtime;
-        LOGV("bootclasspath : %s", runtime8X->boot_class_path_string_.c_str());
-        return runtime8X->heap_;
-    }
+  }
+  return -1;
 }
 
+void ArtHelper::init(JNIEnv* env, int api)
+{
+  ArtHelper::api = api;
+  JavaVM* javaVM;
+  env->GetJavaVM(&javaVM);
+  JavaVMExt* javaVMExt = (JavaVMExt*)javaVM;
+
+  void* runtime = javaVMExt->runtime;
+  if (runtime == nullptr) {
+    return;
+  }
+
+  if (api < ANDROID_R_API) {
+    runtime_instance_ = runtime;
+  } else {
+    int vm_offset = find_offset(runtime, MAX_SEARCH_LEN, javaVM);
+    runtime_instance_ = reinterpret_cast<void*>(reinterpret_cast<char*>(runtime) + vm_offset - offsetof(PartialRuntimeR, java_vm_));
+  }
+}
+
+void* ArtHelper::getJniIdManager()
+{
+  if (runtime_instance_ == nullptr || api < ANDROID_R_API) {
+    return nullptr;
+  }
+  PartialRuntimeR* runtimeR = (PartialRuntimeR*)runtime_instance_;
+  return runtimeR->jni_id_manager_;
+}
+
+void* ArtHelper::getHeap()
+{
+  if (runtime_instance_ == nullptr) {
+    return nullptr;
+  }
+  if (api < 26) {
+    Runtime_7X* runtime7X = (Runtime_7X*)runtime_instance_;
+    return runtime7X->heap_;
+  } else if (api < ANDROID_R_API) {
+    Runtime_8X* runtime8X = (Runtime_8X*)runtime_instance_;
+    LOGV("bootclasspath : %s", runtime8X->boot_class_path_string_.c_str());
+    return runtime8X->heap_;
+  } else {
+    PartialRuntimeR* runtimeR = (PartialRuntimeR*)runtime_instance_;
+    return runtimeR->heap_;
+  }
+}

--- a/library/src/main/cpp/art.h
+++ b/library/src/main/cpp/art.h
@@ -17,11 +17,11 @@
 #ifndef EPIC_ART_H
 #define EPIC_ART_H
 
+#include <jni.h>
+#include <list>
 #include <stdint.h>
 #include <string>
 #include <vector>
-#include <list>
-#include <jni.h>
 
 // Android 6.0: http://androidxref.com/6.0.0_r5/xref/art/runtime/runtime.h
 // Android 7.0: http://androidxref.com/7.0.0_r1/xref/art/runtime/runtime.h
@@ -65,7 +65,6 @@ struct Runtime_7X {
     size_t default_stack_size_;
 
     void* heap_;
-
 };
 
 struct Runtime_8X {
@@ -108,7 +107,40 @@ struct Runtime_8X {
     size_t default_stack_size_;
 
     void* heap_;
+};
 
+struct PartialRuntimeR {
+  void* heap_;
+
+  void* jit_arena_pool_;
+  void* arena_pool_;
+  // Special low 4gb pool for compiler linear alloc. We need ArtFields to be in low 4gb if we are
+  // compiling using a 32 bit image on a 64 bit compiler in case we resolve things in the image
+  // since the field arrays are int arrays in this case.
+  void* low_4gb_arena_pool_;
+
+  // Shared linear alloc for now.
+  void* linear_alloc_;
+
+  // The number of spins that are done before thread suspension is used to forcibly inflate.
+  size_t max_spins_before_thin_lock_inflation_;
+  void* monitor_list_;
+  void* monitor_pool_;
+
+  void* thread_list_;
+
+  void* intern_table_;
+
+  void* class_linker_;
+
+  void* signal_catcher_;
+
+  void* jni_id_manager_;
+
+  void* java_vm_;
+
+  void* jit_;
+  void* jit_code_cache_;
 };
 
 struct JavaVMExt {
@@ -116,6 +148,16 @@ struct JavaVMExt {
     void* runtime;
 };
 
-void *getHeap(JNIEnv*, int);
+class ArtHelper {
+  public:
+    static void init(JNIEnv*, int);
+    static void* getRuntimeInstance() { return runtime_instance_; }
+    static void* getJniIdManager();
+    static void* getHeap();
+
+  private:
+    static void* runtime_instance_;
+    static int api;
+};
 
 #endif //EPIC_ART_H


### PR DESCRIPTION
From Android R, getting method address may involve the jni_id_manager which uses ids mapping instead of directly returning the method address. (https://android-review.googlesource.com/c/platform/art/+/986303). Support to decode method address from such id.