### PR TITLE
Support new API to compile method and new class states in Android R

### DIFF
--- a/library/src/main/cpp/art.cpp
+++ b/library/src/main/cpp/art.cpp
@@ -66,6 +66,15 @@ void* ArtHelper::getJniIdManager()
   return runtimeR->jni_id_manager_;
 }
 
+void* ArtHelper::getJitCodeCache()
+{
+  if (runtime_instance_ == nullptr || api < ANDROID_R_API) {
+    return nullptr;
+  }
+  PartialRuntimeR* runtimeR = (PartialRuntimeR*)runtime_instance_;
+  return runtimeR->jit_code_cache_;
+}
+
 void* ArtHelper::getHeap()
 {
   if (runtime_instance_ == nullptr) {

--- a/library/src/main/cpp/art.cpp
+++ b/library/src/main/cpp/art.cpp
@@ -57,6 +57,15 @@ void ArtHelper::init(JNIEnv* env, int api)
   }
 }
 
+void* ArtHelper::getClassLinker()
+{
+  if (runtime_instance_ == nullptr || api < ANDROID_R_API) {
+    return nullptr;
+  }
+  PartialRuntimeR* runtimeR = (PartialRuntimeR*)runtime_instance_;
+  return runtimeR->class_linker_;
+}
+
 void* ArtHelper::getJniIdManager()
 {
   if (runtime_instance_ == nullptr || api < ANDROID_R_API) {

--- a/library/src/main/cpp/art.h
+++ b/library/src/main/cpp/art.h
@@ -152,6 +152,7 @@ class ArtHelper {
   public:
     static void init(JNIEnv*, int);
     static void* getRuntimeInstance() { return runtime_instance_; }
+    static void* getClassLinker();
     static void* getJniIdManager();
     static void* getJitCodeCache();
     static void* getHeap();

--- a/library/src/main/cpp/art.h
+++ b/library/src/main/cpp/art.h
@@ -153,6 +153,7 @@ class ArtHelper {
     static void init(JNIEnv*, int);
     static void* getRuntimeInstance() { return runtime_instance_; }
     static void* getJniIdManager();
+    static void* getJitCodeCache();
     static void* getHeap();
 
   private:

--- a/library/src/main/java/me/weishu/epic/art/EpicNative.java
+++ b/library/src/main/java/me/weishu/epic/art/EpicNative.java
@@ -58,6 +58,8 @@ public final class EpicNative {
 
     public static native long getMethodAddress(Member method);
 
+    public static native void MakeInitializedClassVisibilyInitialized(long self);
+
     public static native boolean cacheflush(long addr, long len);
 
     public static native long malloc(int sizeOfPtr);
@@ -125,6 +127,11 @@ public final class EpicNative {
     public static Object getObject(long address) {
         final long nativePeer = XposedHelpers.getLongField(Thread.currentThread(), "nativePeer");
         return getObject(nativePeer, address);
+    }
+
+    public static void MakeInitializedClassVisibilyInitialized() {
+        final long nativePeer = XposedHelpers.getLongField(Thread.currentThread(), "nativePeer");
+        MakeInitializedClassVisibilyInitialized(nativePeer);
     }
 
     public static long map(int length) {

--- a/library/src/main/java/me/weishu/epic/art/method/ArtMethod.java
+++ b/library/src/main/java/me/weishu/epic/art/method/ArtMethod.java
@@ -391,6 +391,8 @@ public class ArtMethod {
             Logger.d(TAG, "ensure resolved");
         } catch (Exception ignored) {
             // we should never make a successful call.
+        } finally {
+            EpicNative.MakeInitializedClassVisibilyInitialized();
         }
     }
 


### PR DESCRIPTION
Android R has removed the `jit_compile_method` in the code. This patch makes it to directly invoking the compile method in the `JitCompiler::CompileMethod`. Note that the master branch has a different signature than this methods. Needs to revise later to see what's included in the formal Android R release.
Android_R_Beta_3 library signature: _ZN3art3jit11JitCompiler13CompileMethodEPNS_6ThreadEPNS0_15JitMemoryRegionEPNS_9ArtMethodEbb
Android_Master code signature: _ZN3art3jit11JitCompiler13CompileMethodEPNS_6ThreadEPNS0_15JitMemoryRegionEPNS_9ArtMethodENS_15CompilationKindE

Also, Android R adds a new class states in a [patch](https://android-review.googlesource.com/c/platform/art/+/978710) . If a class is not visibly initialized, it will not be able to update the quick entrypoint after jit compilation. Code site is [here](https://cs.android.com/android/platform/superproject/+/master:art/runtime/jit/jit_code_cache.cc;l=739?q=GetCurrentRegion&ss=android%2Fplatform%2Fsuperproject)