### PR TITLE
Update Entry64.java

### DIFF
--- a/library/src/main/java/me/weishu/epic/art/entry/Entry64.java
+++ b/library/src/main/java/me/weishu/epic/art/entry/Entry64.java
@@ -185,7 +185,7 @@ public class Entry64 {
         } else {
 
             receiver = EpicNative.getObject(self, x1);
-            Logger.i(TAG, "this :" + receiver);
+            //Logger.i(TAG, "this :" + receiver);
 
             do {
                 if (numberOfArgs == 0) break;


### PR DESCRIPTION
在 hook java.util.concurrent.ThreadPoolExecutor 类构造方法的时候，发现报错，报错发生在 toString 方法里面，java.util.concurrent.ThreadPoolExecutor 类的 toString 方法需要用到一个 final 的属性，这个属性为 null。 猜测可能是类实例还没初始化完成就调用了 toString 方法，故这里注释调。