### PR TITLE
Support new API and ArtMethod offsets in Android S

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -10,7 +10,7 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/QMUI">
-        <activity android:name=".MainActivity">
+        <activity android:name=".MainActivity" android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -1,11 +1,11 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 31
 
     defaultConfig {
         minSdkVersion 21
-        targetSdkVersion 29
+        targetSdkVersion 31
         versionCode 1
         versionName "1.0"
 

--- a/library/src/main/java/me/weishu/epic/art/method/Offset.java
+++ b/library/src/main/java/me/weishu/epic/art/method/Offset.java
@@ -121,6 +121,12 @@ class Offset {
             ART_QUICK_CODE_OFFSET.setLength(Offset.BitWidth.QWORD);
             ART_JNI_ENTRY_OFFSET.setLength(BitWidth.QWORD);
             switch (apiLevel) {
+                case Build.VERSION_CODES.S:
+                    // source: https://android.googlesource.com/platform/art/+/refs/heads/android12-release/runtime/art_method.h
+                    ART_QUICK_CODE_OFFSET.setOffset(24);
+                    ART_JNI_ENTRY_OFFSET.setOffset(16);
+                    ART_ACCESS_FLAG_OFFSET.setOffset(4);
+                    break;
                 case Build.VERSION_CODES.R:
                 case Build.VERSION_CODES.Q:
                 case Build.VERSION_CODES.P:

--- a/library/src/main/java/me/weishu/epic/art/method/Offset.java
+++ b/library/src/main/java/me/weishu/epic/art/method/Offset.java
@@ -174,6 +174,12 @@ class Offset {
             ART_QUICK_CODE_OFFSET.setLength(Offset.BitWidth.DWORD);
             ART_JNI_ENTRY_OFFSET.setLength(BitWidth.DWORD);
             switch (apiLevel) {
+                case Build.VERSION_CODES.S:
+                    ART_QUICK_CODE_OFFSET.setOffset(20);
+                    ART_JNI_ENTRY_OFFSET.setOffset(16);
+                    ART_ACCESS_FLAG_OFFSET.setOffset(4);
+                    break;
+                case Build.VERSION_CODES.R:
                 case Build.VERSION_CODES.Q:
                 case Build.VERSION_CODES.P:
                     ART_QUICK_CODE_OFFSET.setOffset(24);


### PR DESCRIPTION
Android S has started to use the new CompileMethod API in #45:
`_ZN3art3jit11JitCompiler13CompileMethodEPNS_6ThreadEPNS0_15JitMemoryRegionEPNS_9ArtMethodENS_15CompilationKindE`
And in the new `ArtMethod` class, some fields are [removed](https://android.googlesource.com/platform/art/+/refs/heads/android12-release/runtime/art_method.h). So new offsets are added to the library.